### PR TITLE
Allow to specify map file location, DEBUG can be configured by env

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ numeric, these are then sent off to Carbon (see example below)
 
 ## Running
 
-* Set the environment variable `MQTT_HOST` to the name/IP of your MQTT broker. (`localhost` is default.)
+* Set the environment variable `DEBUG` and `MQTT_HOST` to the name/IP of your MQTT broker. (`localhost` is default.)
 * Edit the `map` file
-* Run `./mqtt2graphite.py`
+* Run `./mqtt2graphite.py [map file]` if the `map file` is not provided a file called `map` in the current working directory is used
 
 ## Handling numeric payloads
 
@@ -49,8 +49,7 @@ test.jp.j2.size 69.000000 1363169282
 
 A lot. 
 
-* Add configuration file in which we specify username/password, TLS certificates,
-  and path to the "map" file.
+* Add configuration file in which we specify username/password and TLS certificates.
 * I'm not experienced enough with high volume of messages, so this should maybe
   transmit to Carbon via StatsD?
 

--- a/mqtt2graphite.py
+++ b/mqtt2graphite.py
@@ -18,7 +18,7 @@ CARBON_PORT = 2003
 
 LOGFORMAT = '%(asctime)-15s %(message)s'
 
-DEBUG = 1
+DEBUG = os.environ.get('DEBUG', True)
 if DEBUG:
     logging.basicConfig(level=logging.DEBUG, format=LOGFORMAT)
 else:
@@ -130,7 +130,12 @@ if __name__ == '__main__':
     logging.debug("DEBUG MODE")
 
     map = {}
-    f = open('map')
+    if len(sys.argv) > 1:
+        map_file = sys.argv[1]
+    else:
+        map_file = 'map'
+
+    f = open(map_file)
     for line in f.readlines():
         line = line.rstrip()
         if len(line) == 0 or line[0] == '#':


### PR DESCRIPTION
As tittle suggest this PR allow the user to pass a map file using command line and configure DEBUG by env var